### PR TITLE
Fix type for uploads process route

### DIFF
--- a/src/routes/archives.ts
+++ b/src/routes/archives.ts
@@ -3,7 +3,7 @@
  * POST /api/v1/archives/upload - Upload and process ZIP files
  */
 
-import express from 'express';
+import express, { Request, Response } from 'express';
 import multer from 'multer';
 import * as fs from 'fs-extra';
 import { addArchiveJob } from '../services/queue';
@@ -137,7 +137,7 @@ router.get('/api/v1/uploads/list', async (req, res) => {
 });
 
 // Processar arquivo selecionado
-router.post('/api/v1/uploads/process', (req, res) => {
+router.post('/api/v1/uploads/process', (req: Request, res: Response) => {
   const { filename, nomeProprio } = req.body;
   if (!filename) return res.status(400).json({ error: 'Arquivo não informado' });
   try {


### PR DESCRIPTION
## Summary
- import Request and Response in archives route
- type `router.post('/api/v1/uploads/process')` handler parameters

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_685d86939ac48330bea8652de31ec009