### PR TITLE
Add Prisma offline note

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ npm run lint         # Linting
 npm start           # Iniciar produção
 ```
 
+
+### Gerar Prisma Client offline
+
+Caso sua rede bloqueie acessos a `binaries.prisma.sh`, baixe as engines do Prisma em outra máquina e copie para um diretório (ex.: `prisma-engines`). Defina `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` e exporte os caminhos das engines antes de gerar o client:
+
+```bash
+export PRISMA_QUERY_ENGINE_BINARY=./prisma-engines/query-engine
+export PRISMA_QUERY_ENGINE_LIBRARY=./prisma-engines/libquery_engine.so
+export PRISMA_SCHEMA_ENGINE_BINARY=./prisma-engines/schema-engine
+export PRISMA_FMT_BINARY=./prisma-engines/prisma-fmt
+export PRISMA_INTROSPECTION_ENGINE_BINARY=./prisma-engines/introspection-engine
+PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate
+```
+
 ## Deployment
 
 ### Opções de Deploy


### PR DESCRIPTION
## Summary
- document how to generate Prisma client offline when network access to binaries.prisma.sh is blocked

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d8985b1388330a5489feec6a32775