### PR TITLE
Fix archives route typing

### DIFF
--- a/src/routes/archives.ts
+++ b/src/routes/archives.ts
@@ -37,7 +37,7 @@ const upload = multer({
  * POST /api/v1/archives/upload
  * Upload and queue ZIP file for processing
  */
-router.post('/upload', upload.single('file'), async (req, res): Promise<void> => {
+router.post('/upload', upload.single('file'), async (req: Request, res: Response): Promise<void> => {
   try {
     if (!req.file) {
       res.status(400).json({


### PR DESCRIPTION
## Summary
- type request and response parameters in archives route

## Testing
- `npm test` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_b_685d89834f848330bf36d0baeecdd2cf