### PR TITLE
Add API routers to app setup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,10 @@ import n8nRouter from './routes/n8n';
 import embeddingsRouter from './routes/embeddings';
 import searchRouter from './routes/search';
 import chatRouter from './routes/chat';
+import archivesRouter from './routes/archives';
+import reportsRouter from './routes/reports';
+import incidentsRouter from './routes/incidents';
+import patternsRouter from './routes/patterns';
 import { getFaissManager } from './faissManager';
 
 export class NCrisisApp {
@@ -109,6 +113,10 @@ export class NCrisisApp {
     this.app.use('/api/v1/embeddings', embeddingsRouter);
     this.app.use('/api/v1/search', searchRouter);
     this.app.use('/api/v1/chat', chatRouter);
+    this.app.use('/api/v1/archives', archivesRouter);
+    this.app.use('/api/v1/reports', reportsRouter);
+    this.app.use('/api/v1/incidents', incidentsRouter);
+    this.app.use('/api/v1/patterns', patternsRouter);
 
     // Serve React frontend
     const frontendPath = path.join(__dirname, '../frontend/dist');


### PR DESCRIPTION
## Summary
- import all API routers in `src/app.ts`
- mount archives, reports, incidents and patterns routes

## Testing
- `npm test` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_b_685d922e09bc8330a6c9f7bbc4e706a0