### PR TITLE
Ensure Prisma client generation before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ npm run lint         # Linting
 npm start           # Iniciar produção
 ```
 
+Antes de rodar os testes, garanta que o Prisma Client foi gerado:
+
+```bash
+npx prisma generate
+```
+
 
 ### Gerar Prisma Client offline
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,11 @@
  * Global configuration for test environment
  */
 
+import { execSync } from 'child_process';
+
+// Ensure Prisma Client is generated before tests
+execSync('npx prisma generate', { stdio: 'inherit' });
+
 import { PrismaClient } from '@prisma/client';
 
 // Setup test database


### PR DESCRIPTION
## Summary
- run `npx prisma generate` in Jest setup so the Prisma client is initialized
- document the generate step in README

## Testing
- `npm test` *(fails: Failed to fetch checksum from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_b_685d9230ea148330b093d49501f9d42e